### PR TITLE
Remove error when empty zones appear in the config, skip them instead

### DIFF
--- a/dkroutingtool/Dockerfile.dev
+++ b/dkroutingtool/Dockerfile.dev
@@ -16,7 +16,7 @@ ARG osm_filename_arg
 
 ENV osm_filename $osm_filename_arg
 
-RUN wget $osm_download_url
+RUN wget --no-check-certificate $osm_download_url
 
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh
 

--- a/dkroutingtool/src/py/main_application.py
+++ b/dkroutingtool/src/py/main_application.py
@@ -69,9 +69,10 @@ def run_routing_from_config(config_file='data/config.json', output_dir=file_conf
         node_data = build_time_dist_matrix.process_nodes(config['node_loader_options'], config['zone_configs'])
     else:
         node_data = build_time_dist_matrix.process_nodes()
-        errors = routing_config.validate_against_node_data(node_data)
-        if errors:
-            raise ValueError("Node validation against config failed:" + '\n'.join(errors))
+    
+    errors = routing_config.validate_against_node_data(node_data)
+    if errors:
+        raise ValueError("Node validation against config failed:" + '\n'.join(errors))
 
     print(f' *   Starting Model Run at {time.strftime("%H:%M:%S")} (UTC)')
     # Check if solver options are specified

--- a/dkroutingtool/src/py/routing_configuration.py
+++ b/dkroutingtool/src/py/routing_configuration.py
@@ -7,6 +7,7 @@ Config.json files shoudl contain
 
 example file is in local_data/config.json
 """
+import sys
 import json
 from typing import List
 
@@ -76,7 +77,14 @@ class RoutingConfig:
             for z in zc['optimized_region']:
                 record_count = node_data.filter_nodedata({'zone': z}).all_clean_nodes.shape[0]
                 if record_count == 0:
-                    errors.append((f"Data Error: No Customers in Zone {z}, perhaps this is an error. Stopping Run! "))
+                    zc['optimized_region'].remove(z)
+                    print(f"Data check: No customers in zone {z}, perhaps this is an error. The zone will not be computed")
+                    
+        # Eliminating empty zone configs, as a zone config can cover many zones but they may all get removed previously 
+        for zc in config['zone_configs']:
+          if len(zc['optimized_region']) == 0:
+            config['zone_configs'].remove(zc)
+
         return errors
 
     def validate_against_node_data(self, node_data: 'NodeData') -> List[str]:
@@ -87,7 +95,7 @@ class RoutingConfig:
         Returns:
           List of errors or empty list if none.
         """
-        errors = self.verify_all_zones_have_customers(config, node_data)
+        errors = self._verify_all_zones_have_customers(node_data)
         return errors
 
     def validate(self) -> List[str]:


### PR DESCRIPTION
Removes the name from the zone config, or the whole zone config if the list of zones it covers becomes empty 