### PR TITLE
Enable container port access on local mac (and likely windows) runs

### DIFF
--- a/dkroutingtool/Makefile
+++ b/dkroutingtool/Makefile
@@ -2,10 +2,10 @@ build:
 	sh s_build_docker_dev.sh
 
 interact:
-	docker run --name server --rm --network host -it ghcr.io/datakind/dk-routing:main bash
+	docker run --name server --rm -p 5001:5001 -it ghcr.io/datakind/dk-routing:main bash
 
 run_and_serve:
-	docker run --name server --network host -d --rm ghcr.io/datakind/dk-routing:main /opt/conda/bin/python src/py/server.py
+	docker run --name server -p 5001:5001 -d --rm ghcr.io/datakind/dk-routing:main /opt/conda/bin/python src/py/server.py
 
 serve:
 	/opt/conda/bin/python /src/py/server.py &
@@ -15,10 +15,27 @@ test:
 
 dockergui:
 	cd src/py/ui && docker build -t dashboard -f dashboard.dockerfile . 
-	docker run --name dashboard --network host -d --rm dashboard:latest
+	docker run -e SERVER_HOST='localhost' --name dashboard --network host -d --rm dashboard:latest
 
 gui:
-	cd src/py/ui && streamlit run dashboard.py
+	export SERVER_HOST='localhost' && cd src/py/ui && streamlit run dashboard.py
 
 #go to http://localhost:8501/ in your browser and it should work
-demo: run_and_serve dockergui
+demo:
+	cd src/py/ui && docker build -t dashboard -f dashboard.dockerfile .
+	docker run \
+		--add-host=host.docker.internal:host-gateway \
+		--name server \
+		-p 5001:5001 \
+		-d \
+		--rm \
+		ghcr.io/datakind/dk-routing:main \
+		/opt/conda/bin/python src/py/server.py
+	docker run \
+		-e SERVER_HOST='host.docker.internal' \
+		--add-host=host.docker.internal:host-gateway \
+		--name dashboard \
+		-p 8501:8501 \
+		-d \
+		--rm \
+		dashboard:latest

--- a/dkroutingtool/src/py/ui/dashboard.py
+++ b/dkroutingtool/src/py/ui/dashboard.py
@@ -7,10 +7,11 @@ import streamlit.components.v1 as components
 from folium.plugins import Draw
 from streamlit_folium import st_folium
 import folium
+import os
 
 st.set_page_config(page_title='Container-based Action Routing Tool (CART)', layout="wide")
 
-host_url = 'http://localhost:5001'
+host_url = 'http://{}:5001'.format(os.environ['SERVER_HOST'])
 
 def download_solution(solution_path, map_path):
     timestamp = datetime.datetime.now().strftime(format='%Y%m%d-%H-%M-%S')


### PR DESCRIPTION
Aiming to create a fix for local Mac and Windows docker-based runs, issue [55](https://github.com/datakind/dk-routing/issues/55).

Also addresses the issue that `--network=host` is unreachable on those hosts: ["The host networking driver only works on Linux hosts, and is not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server."](https://docs.docker.com/network/drivers/host/)

