### PR TITLE
Make it possible to update vehicles or maps via streamlit

### DIFF
--- a/dkroutingtool/src/py/ui/dashboard.py
+++ b/dkroutingtool/src/py/ui/dashboard.py
@@ -46,8 +46,10 @@ def request_solution():
 def request_map(bounding_box):
     response = requests.get(f'{host_url}/request_map/?minlat={bounding_box[0]}&minlon={bounding_box[1]}&maxlat={bounding_box[2]}&maxlon={bounding_box[3]}')
     
-
     return True
+
+def update_vehicle_or_map():
+    response = requests.post(f'{host_url}/update_vehicle_or_map/?session_id={session_id}')
 
 def adjust(adjusted_file):
     headers = {
@@ -88,7 +90,8 @@ def upload_data(files_from_streamlit):
 def main():
     st.header('Container-based Action Routing Tool (CART)')
 
-    st.write('Available vehicle profiles: '+ requests.get(f'{host_url}/available_vehicles').json()['message'])
+    vehicles_text = st.empty()
+    vehicles_text.text('Available vehicle profiles: '+ requests.get(f'{host_url}/available_vehicles').json()['message'])
     
     st.write('If required, draw a rectangle over the area you want to use for routing. Download it again only if you updated the OpenStreetMap data. Please select an area as small as possible.')
     m = folium.Map(location=[-11.9858, -77.019], zoom_start=5)
@@ -114,6 +117,11 @@ def main():
     if len(uploaded_files) > 0:
         response = upload_data(uploaded_files)
         st.write(response)
+        vehicle_or_map_update_requested = st.button('If updated vehicles + updated build_paramters.yml or a *.osm.pbf map was uploaded, click here to update.')
+        if vehicle_or_map_update_requested:
+            with st.spinner('Rebuilding based on updated vehicles/maps. This may take a few minutes, please wait...'):
+                update_vehicle_or_map()
+            vehicles_text.text('Available vehicle profiles: '+ requests.get(f'{host_url}/available_vehicles').json()['message'])
 
     st.write('Calculating a solution will take up to twice the amount of time specified by the config file')
     


### PR DESCRIPTION
Background:
Adding in the ability to upload .lua files (with a corresponding build_parameters.yml) file so vehicle profiles can be updated via the streamlit app. Added the ability for *.osm.pbf maps to be uploaded also (happens to be helpful for our use case, but may be generally useful).

Functional Changes:
This update adds in a conditional button that appears when files are uploaded. The 'Available vehicle profiles:' text at the top of the app should also update (if any vehicles are changed/updated).
* If a file exactly matches `build_parameters.yml`, will be moved from the upload folder to the root folder.
* Vehicle files with `*.lua` extension will all be copied to the `/osrm-backend/profiles` folder.
* Map files with a `*.pbf` extension will be copied to the root folder, renamed to `upload_map.osm`, and and `osm_filename` environment variable will be updated (akin to the request_map function).

If any of the above occur, the temporary_build_profiles() function will be run, which should (?) update both the map and vehicles.

Should address [Issue 58](https://github.com/datakind/dk-routing/issues/58).