### PR TITLE
Enable CART to run out of the box

### DIFF
--- a/dkroutingtool/Dockerfile.dev
+++ b/dkroutingtool/Dockerfile.dev
@@ -101,6 +101,6 @@ RUN pip uninstall -y typing-extensions && pip install typing-extensions==4.7.1
 
 COPY src src
 
-ENV PYTHONPATH "${PYTHONPATH}:./py-lib:/src/python"
+ENV PYTHONPATH "${PYTHONPATH}:/py-lib:/src/python"
 
 CMD ["/opt/conda/bin/python", "src/py/main_application.py", "--local"]

--- a/dkroutingtool/src/py/config/config_manager.py
+++ b/dkroutingtool/src/py/config/config_manager.py
@@ -55,7 +55,7 @@ class ConfigManager(object):
 
         return ConfigManager.load(ConfigFileLocations(
                 routing_config_file=f"{local_dir}/config.json",
-                build_parameters_file='build_parameters.yml',
+                build_parameters_file=f"{local_dir}/../build_parameters.yml",
                 gps_input_files=GPSInputPaths(
                     gps_file=f"{local_dir}/customer_data.xlsx",
                     custom_header_file=f"{local_dir}/custom_header.yaml",
@@ -82,7 +82,7 @@ class ConfigManager(object):
         return ConfigManager.load(
             ConfigFileLocations(
                 routing_config_file=f"{local_dir}/config.json",
-                build_parameters_file='build_parameters.yml',
+                build_parameters_file=f"{local_dir}/../build_parameters.yml",
                 gps_input_files=GPSInputPaths(
                     gps_file=f"{local_dir}/customer_data.xlsx",
                     custom_header_file=f"{local_dir}/custom_header.yaml",

--- a/dkroutingtool/src/py/main_application.py
+++ b/dkroutingtool/src/py/main_application.py
@@ -38,7 +38,7 @@ gpx_output = True
 
 def main(user_directory='data'):
     OUTPUT_DATA_DIR = f'WORKING_DATA_DIR/{user_directory}/output_data/'
-    INPUT_DATA_DIR = f'WORKING_DATA_DIR/{user_directory}/input_data/' # should test cloud setting eventually
+    INPUT_DATA_DIR = f'{user_directory}' # should test cloud setting eventually
     
     timestamp = time.strftime("%Y_%m_%d_%H_%M")
     logging.info(f"Model Run Initiated {timestamp} (UTC)")

--- a/dkroutingtool/src/py/server.py
+++ b/dkroutingtool/src/py/server.py
@@ -9,6 +9,7 @@ import shutil
 import requests
 import os
 import subprocess
+import shutil
 
 app = fastapi.FastAPI()
 
@@ -34,8 +35,12 @@ def get_solution(session_id: str=''):
     main_application.args.cloud = False
     main_application.args.manual_mapping_mode = False
     main_application.args.manual_input_path = None
-
-    main_application.main(user_directory=f'data{session_id}')
+    # For demo purposes, if the user hasn't uploaded any when asking for a solution,
+    #   use a defaults directory:
+    if 'session_id' in locals():
+        main_application.main(user_directory=f'data{session_id}')
+    else:
+        main_application.main(user_directory=f'/data')
     return {'message': 'Done'}
 
 

--- a/dkroutingtool/src/py/ui/dashboard.py
+++ b/dkroutingtool/src/py/ui/dashboard.py
@@ -19,7 +19,10 @@ host_url = 'http://{}:5001'.format(os.environ['SERVER_HOST'])
 
 def download_solution(solution_path, map_path):
     timestamp = datetime.datetime.now().strftime(format='%Y%m%d-%H-%M-%S')
-    response = requests.get(f'{host_url}/download/?session_id={session_id}')
+    if 'session_id' in locals():
+        response = requests.get(f'{host_url}/download/?session_id={session_id}')
+    else:
+        response = requests.get(f'{host_url}/download')
 
     solution_zip = response.content
 
@@ -38,7 +41,10 @@ def download_solution(solution_path, map_path):
     return solution, map, solution_zip
 
 def request_solution():
-    response = requests.get(f'{host_url}/get_solution/?session_id={session_id}')
+    if 'session_id' in locals():
+        response = requests.get(f'{host_url}/get_solution/?session_id={session_id}')
+    else:
+        response = requests.get(f'{host_url}/get_solution')
     solution, map, solution_zip = download_solution(solution_path='solution.txt', map_path='/maps/route_map.html')
 
     return solution, map, solution_zip


### PR DESCRIPTION
Did my best to enable an out of the box run. I.e. a `make demo` would run if the user doesn't make any changes, and just clicks `Click here to calculate routes`. This didn't work for a few different reasons detailed below (each corresponds to a commit). **These were my best guesses, and may need some tweaking to keep in line with the vision of the project.**

* The compiled OSRM python library bindings couldn't be found by python, so the adjusting the python path environment variable was updated to be an absolute path.
* The `build_parameter.yml` file was expected to be in the same path python is started from, but the container does not start python in the root directory. There may be better solutions that what I've done, but specifying the path to `build_parameter.yml` as one directory level below `local_dir` seems to be resilient to both containerized and host-based runs. It is, however, generally brittle due to being specified in a different location than runs are specified (e.g. will break if another directory layer is added between the data folders and the root directory). This does work for the time being. Is the root directory where `build_parameter.yml` should be located?
* Uploaded files are dropped into the `/data{session_id}` folder, which is not the same as the `WORKING_DATA_DIR` path. Updated the `INPUT_DATA_DIR` to correctly reflect this (I think this is intended behavior given the upload paths created by the streamlit app). Also, for the out of the box (oob) behavior, there is no session id, so `get_solution()` was updated to enable oob runs. 
*`request_solution()` and `download_solution()` were also updated to enable oob runs.


Address [Issue 60](https://github.com/datakind/dk-routing/issues/60).