### PR TITLE
replace missing osrm branch git pull with release v5.24

### DIFF
--- a/dkroutingtool/Dockerfile.dev
+++ b/dkroutingtool/Dockerfile.dev
@@ -8,7 +8,9 @@ RUN apt-get update
 
 RUN apt-get -y install git g++ cmake libboost-dev libboost-filesystem-dev libboost-thread-dev libboost-system-dev libboost-regex-dev libstxxl-dev libxml2-dev libsparsehash-dev libbz2-dev zlib1g-dev libzip-dev libgomp1 lua5.2 liblua5.2-dev libluabind-dev pkg-config libgdal-dev libboost-program-options-dev libboost-iostreams-dev libboost-test-dev libtbb-dev libexpat1-dev wget
 
-RUN git clone -b 5.21 --single-branch https://github.com/Project-OSRM/osrm-backend.git
+RUN wget https://github.com/Project-OSRM/osrm-backend/archive/refs/tags/v5.24.0.tar.gz && \
+    tar -xvf v5.24.0.tar.gz && \
+    mv /osrm-backend-5.24.0 /osrm-backend
 
 COPY /c_binding_resources/table_parameters.hpp osrm-backend/include/engine/api/table_parameters.hpp
 


### PR DESCRIPTION
Aiming to address [Issue 63](https://github.com/datakind/dk-routing/issues/63)

Replacing git pull of osrm-backend branch 5.21 with [release 5.24](https://github.com/Project-OSRM/osrm-backend/issues/5946). Build was successful when tested by building locally, but could use a review. 

Thanks!